### PR TITLE
Restrict IA Upload filenames to 240 bytes

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -37,6 +37,7 @@
 	"upload-time-warning": "(Warning: the upload may take more than one minute!)",
 	"set-all-fields": "Please set all fields of the form",
 	"invalid-commons-name": "'$1' is not a valid file name for Wikimedia Commons",
+	"invalid-length": "'$1' is too long",
 	"no-found-on-ia": "'$1' is not a valid Internet Archive identifier",
 	"already-on-commons": "A file named '$1' already exists on Wikimedia Commons",
 	"creator-template-missing": "The author '$1' doesn’t have a <a href='https://commons.wikimedia.org/wiki/Commons:Creator'>creator</a> template. If you know their Wikidata ID, you can <a href='https://tools.wmflabs.org/wikidata-todo/creator_from_wikidata.php'>create the template now</a>."

--- a/src/IaUpload/CommonsController.php
+++ b/src/IaUpload/CommonsController.php
@@ -158,6 +158,14 @@ class CommonsController {
 				'error' => $this->app['i18n']->message( 'set-all-fields' ),
 			] );
 		}
+		// Ensure that file name is less than or equal to 240 bytes.
+		if ( strlen( $commonsName ) > 240 ) {
+			return $this->outputsInitTemplate( [
+				'iaId' => $iaId,
+				'commonsName' => $commonsName,
+				'error' => $this->app['i18n']->message( 'invalid-length', [ $commonsName ] ),
+			] );
+		}
 		// Strip any trailing file extension.
 		if ( preg_match( '/^(.*)\.(pdf|djvu)$/', $commonsName, $m ) ) {
 			$commonsName = $m[1];


### PR DESCRIPTION
Uses `strlen()` to count number of bytes in string. Created new error message 'invalid-length' which will need translating, alternatively we could use 'invalid-commons-name' which is already translated, but is less descriptive.

Bug: [T165014](https://phabricator.wikimedia.org/T165014)