### PR TITLE
Uses ImageMagick instead of GraphicsMagick

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and read the documentation at [wikitech.wikimedia.org/wiki/Tool:IA_Upload](https
 ## Prerequesites
 The actual format conversions are done by the following external tools, called from within IA Upload:
 
-1. [GraphicsMagick](http://www.graphicsmagick.org)
+1. [ImageMagick](https://www.imagemagick.org)
 2. [DjVuLibre](https://sourceforge.net/p/djvu/)
 
 ## Installation

--- a/src/DjvuMaker/Jp2DjvuMaker.php
+++ b/src/DjvuMaker/Jp2DjvuMaker.php
@@ -119,7 +119,7 @@ class Jp2DjvuMaker extends DjvuMaker {
 			if ( !file_exists( $jpgFile ) ) {
 				$this->log->debug( "...to $jpgFile" );
 				$convertArgs = "-resize 1500x1500 \"$jp2File\" \"$jpgFile\"";
-				$this->runCommand( 'gm convert', $convertArgs );
+				$this->runCommand( 'convert', $convertArgs );
 			}
 
 			// Make DjVu file of this page. Use the item identifier as the filename instead of


### PR DESCRIPTION
ImageMagick is more widespread and now supports JPEG 2000

The version installed on ToolsLabs Debian Stretch instances seems to work properly with JPEG 2000.

Should solve https://phabricator.wikimedia.org/T215647