### PR TITLE
Toolforge URLs and switch to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        php: [ '7.2' ]
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{matrix.php}}
+        extensions: zip
+
+    - name: Install
+      run: |
+        composer install
+
+    - name: Test
+      run: |
+        composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: php
-php: '7.2'
-install: composer install
-script: composer test

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 Internet Archive Upload Tool
 ============================
 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/Tpt/ia-upload/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/Tpt/ia-upload/?branch=master)
-[![Build Status](https://travis-ci.org/wikisource/ia-upload.svg?branch=master)](https://travis-ci.org/wikisource/ia-upload)
-[![Dependency Status](https://www.versioneye.com/user/projects/58a64b614ca76f004ed471fa/badge.svg?style=flat-square)](https://www.versioneye.com/user/projects/58a64b614ca76f004ed471fa)
+![CI](https://github.com/wikisource/ia-upload/workflows/CI/badge.svg)
 
 A small tool to import DjVu files from Internet Archive to Wikimedia Commons.
-See it in operation at [tools.wmflabs.org/ia-upload/](https://tools.wmflabs.org/ia-upload/)
+See it in operation at [ia-upload.toolforge.org](https://ia-upload.toolforge.org/)
+(or the test site at [ia-upload-test.toolforge.org](https://ia-upload-test.toolforge.org/))
 and read the documentation at [wikitech.wikimedia.org/wiki/Tool:IA_Upload](https://wikitech.wikimedia.org/wiki/Tool:IA_Upload).
 
 ## Prerequesites
@@ -28,7 +27,7 @@ The actual format conversions are done by the following external tools, called f
 
    * For Lighttpd, use:
 
-         url.rewrite-if-not-file += ( "(.*)" => "index.php/$0" )
+         url.rewrite-if-not-file += ( "/(.*)" => "/index.php$0" )
 
 4. Register an oAuth consumer on [Meta](https://meta.wikimedia.org/wiki/Special:OAuthConsumerRegistration)
    with a callback to e.g. `http://localhost/ia-upload/public/oauth/callback` (i.e. ending in `oauth/callback`)

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -42,7 +42,7 @@
 	"invalid-length": "'$1' is too long",
 	"no-found-on-ia": "'$1' is not a valid Internet Archive identifier",
 	"already-on-commons": "A file named '$1' already exists on Wikimedia Commons",
-	"creator-template-missing": "The author '$1' doesn’t have a <a href='https://commons.wikimedia.org/wiki/Commons:Creator'>creator</a> template. If you know their Wikidata ID, you can <a href='https://tools.wmflabs.org/wikidata-todo/creator_from_wikidata.php'>create the template now</a>.",
+	"creator-template-missing": "The author '$1' doesn’t have a <a href='https://commons.wikimedia.org/wiki/Commons:Creator'>creator</a> template.",
 	"no-usable-files-found": "No usable files (DjVu, PDF, or JP2) were found for that item.",
 	"successfully-uploaded": "$1 has been successfully uploaded to Commons!",
 	"recent-uploads": "Recent uploads",

--- a/public/toolinfo.json
+++ b/public/toolinfo.json
@@ -2,7 +2,7 @@
 	"name" : "ia-upload",
 	"title" : "IA Upload",
 	"description" : "A tool to upload Internet Archive files to Wikimedia Commons",
-	"url" : "https://tools.wmflabs.org/ia-upload/",
+	"url" : "https://ia-upload.toolforge.org/",
 	"keywords" : "Wikisource, Internet Archive, DjVu, PDF, conversion, upload",
 	"author" : "Tpt, Sam Wilson",
 	"repository" : "https://github.com/wikisource/ia-upload.git"

--- a/views/template.twig
+++ b/views/template.twig
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8" />
 	<title>{{ 'ia-upload'|message }}</title>
-	<link rel="stylesheet" href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css">
+	<link rel="stylesheet" href="https://tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.3.6/css/bootstrap.min.css">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<style type="text/css">
 		html, body {


### PR DESCRIPTION
* Fix Toolforge URLs.
* Switch away from Travis, Scrutinizer, and VersionEye, to just
  running CI on GitHub Actions.
* Don't link to the creator template tool, as it's deprecated.