### PR TITLE
Make DJVU the default

### DIFF
--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -185,7 +185,7 @@ class UploadController {
 		$query = $request->getQueryParams();
 		$iaId = trim( $query['iaId'] ?? '' );
 		$commonsName = $this->commonsClient->normalizePageTitle( $query['commonsName'] ?? '' );
-		$format = $query['format'] ?? 'pdf';
+		$format = $query['format'] ?? 'djvu';
 		$fileSource = $query['fileSource'] ?? 'djvu';
 		// Validate inputs.
 		if ( $iaId === '' || $commonsName === '' ) {
@@ -464,7 +464,7 @@ class UploadController {
 			'iaId' => '',
 			'commonsName' => '',
 			'jobs' => [],
-			'format' => 'pdf',
+			'format' => 'djvu',
 			'wiki_base_url' => $this->config['wiki_base_url'],
 		];
 		$params = array_merge( $defaultParams, $params );


### PR DESCRIPTION
Firstly DJVU is often easier to work with at Wikisource than PDF,
the thumbnails render much faster and the text layer is generally
better.

Also a massive PDF upload means it's highly likely that a user is
looking to upload a DVJU in preference to the PDF (if they wanted
a PDF, that's probably already at Commons).