### PR TITLE
[WIP] Make Commons filename editable

### DIFF
--- a/views/commons/fill.twig
+++ b/views/commons/fill.twig
@@ -15,7 +15,7 @@
 				<label for="commonsName" class="col-lg-2 control-label">{{ 'form-label-commons-name'|message }}</label>
 				<div class="col-lg-10">
 					<span class="input-group">
-						<input name="commonsName" id="commonsName" type="text" size="30" required="required" readonly="readonly" class="form-control" value="{{ commonsName|e }}" />
+						<input name="commonsName" id="commonsName" type="text" size="30" required="required" class="form-control" value="{{ commonsName|e }}" />
 						<span class="input-group-addon">.{{ format }}</span>
 					</span>
 				</div>


### PR DESCRIPTION
This allows users to adjust the name based on the title returned
in the IA metadata

Bug: T271423

-----

This allows the user to violate the assumptions like no colons and can lead to a failed upload. Not quite sure how best to handle.