### PR TITLE
Recent uploads link should use configured URL

### DIFF
--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -503,6 +503,7 @@ class UploadController {
 			'error' => '',
 			'user' => $this->c->get( 'session' )->get( 'user' ),
 			'oauth_cid' => isset( $this->config[ 'consumerId' ] ) ? $this->config[ 'consumerId' ] : '',
+			'base_url' => $this->config['wiki_base_url'],
 		];
 		$params = array_merge( $defaultParams, $params );
 		return $this->c->get( 'view' )->render( $response, $templateName, $params );

--- a/views/template.twig
+++ b/views/template.twig
@@ -49,7 +49,7 @@
 			<div class="page-header">
 				<ul class="pull-right list-inline">
 					<li>
-						<a href="https://commons.wikimedia.org/wiki/Special:RecentChanges?tagfilter=OAuth+CID%3A+{{ oauth_cid }}"
+						<a href="{{ base_url }}/wiki/Special:RecentChanges?tagfilter=OAuth+CID%3A+{{ oauth_cid }}"
 						   target="_blank" title="{{ 'recent-uploads-tooltip'|message }}">
 							{{ 'recent-uploads'|message }}
 						</a>


### PR DESCRIPTION
Otherwise it's always pointing at Commons, even if you're
using the beta cluster.